### PR TITLE
Modified WPF+SparsePkg demo so that it correctly defines the P/Invoke…

### DIFF
--- a/Samples/SparsePackages/PhotoStoreDemo/ExecutionMode.cs
+++ b/Samples/SparsePackages/PhotoStoreDemo/ExecutionMode.cs
@@ -11,7 +11,7 @@ namespace PhotoStoreDemo
     {
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        static extern int GetCurrentPackageFullName(ref int packageFullNameLength, ref StringBuilder packageFullName);
+        static extern int GetCurrentPackageFullName(ref int packageFullNameLength, StringBuilder packageFullName);
 
         internal static bool IsRunningWithIdentity()
         {
@@ -23,12 +23,47 @@ namespace PhotoStoreDemo
             {
                 StringBuilder sb = new StringBuilder(1024);
                 int length = 0;
-                int result = GetCurrentPackageFullName(ref length, ref sb);
+                int result = GetCurrentPackageFullName(ref length, sb);
 
                 return result != 15700;
             }
         }
 
+        internal static string GetCurrentPackageFullName()
+        {
+            if (isWindows7OrLower())
+            {
+                System.Diagnostics.Debug.WriteLine("Appmodel packaging is not available on this version of Windows.");
+                return null;
+            }
+            else
+            {
+                StringBuilder sb = new StringBuilder(1024);
+                int length = 0;
+                int result = GetCurrentPackageFullName(ref length, sb);
+
+                if (result != 15700)
+                {
+                    sb.EnsureCapacity(length);
+                    result = GetCurrentPackageFullName(ref length, sb);
+                    if (result == 0)
+                    {
+                        return sb.ToString();
+                    }
+                    else
+                    {
+                        System.ComponentModel.Win32Exception win32Exception = new System.ComponentModel.Win32Exception(result);
+                        System.Diagnostics.Debug.WriteLine(win32Exception.Message);
+                    }
+                }
+                else
+                {
+                    System.ComponentModel.Win32Exception win32Exception = new System.ComponentModel.Win32Exception(result);
+                    System.Diagnostics.Debug.WriteLine(win32Exception.Message);
+                }
+                return null;
+            }
+        }
         private static bool isWindows7OrLower()
         {
             int versionMajor = Environment.OSVersion.Version.Major;

--- a/Samples/SparsePackages/PhotoStoreDemo/StartUp.cs
+++ b/Samples/SparsePackages/PhotoStoreDemo/StartUp.cs
@@ -210,13 +210,22 @@ namespace PhotoStoreDemo
         private static void removeSparsePackage() //example of how to uninstall a Sparse Package
         {
             PackageManager packageManager = new PackageManager();
-            Windows.Foundation.IAsyncOperationWithProgress<DeploymentResult, DeploymentProgress> deploymentOperation = packageManager.RemovePackageAsync("PhotoStoreDemo_0.0.0.1_x86__rg009sv5qtcca");
-            ManualResetEvent opCompletedEvent = new ManualResetEvent(false); // this event will be signaled when the deployment operation has completed.
+            string packageFullName = ExecutionMode.GetCurrentPackageFullName();
+            if (packageFullName != null)
+            {
+                Windows.Foundation.IAsyncOperationWithProgress<DeploymentResult, DeploymentProgress> deploymentOperation = packageManager.RemovePackageAsync(packageFullName);
+                ManualResetEvent opCompletedEvent = new ManualResetEvent(false); // this event will be signaled when the deployment operation has completed.
 
-            deploymentOperation.Completed = (depProgress, status) => { opCompletedEvent.Set(); };
+                deploymentOperation.Completed = (depProgress, status) => { opCompletedEvent.Set(); };
 
-            Debug.WriteLine("Uninstalling package..");
-            opCompletedEvent.WaitOne();
+                Debug.WriteLine("Uninstalling package {0}", packageFullName);
+                opCompletedEvent.WaitOne();
+                Debug.WriteLine("Package {0} successfully uninstalled.", packageFullName);
+            }
+            else
+            {
+                Debug.WriteLine("Could not uninstall package, there was an error getting the package name.");
+            }
         }
 
     }


### PR DESCRIPTION
… signature for the kerner32.dll function GetCurrentPackageFullName. Added the ability to get the package full name via the new ExecutionMode.GetCurrentPackageFullName method and incorporated that into the StartUp.removeSparsePackage method to provide a complete example of how to remove the sparse package that has been installed. This resolves issue #17 .